### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ smf:
         - "25:25"
     environment:
         - SMF_CONFIG=testi@testo.com:test@test.com:test
-    tags:
-        - mx
+        
     deployment_strategy: high_availability
     restart: always


### PR DESCRIPTION
Not sure if tags is needed to deploy to Tutum. However, tags is not supported with the latest version of docker-compose.

Great tool BTW. Thanks for the contribution!