### PR TITLE
allow multiple forwards separated by |

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ $ export SMF_CONFIG='testi@testo.com:test@test.com'
 ```
 > You could get the ESMTP AUTH password for you on your docker log. It's randomly generated if you do not provide one.
 
+You can also forward all emails received by testi@testo.com to multiple destination addresses:
+
+```bash
+$ export SMF_CONFIG='testi@testo.com:test1@test.com|test2@test.com|test3@test.com'
+```
+
 #### 2. Advanced
 Add ESMTP AUTH password:
 ```bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,6 +67,9 @@ function start_postfix {
 
         emailFrom=${emailPair[0]}
         emailTo=${emailPair[1]}
+        emailToArr=(${emailTo//|/ })
+        emailTo=$(printf "\t%s" "${emailToArr[@]}")
+        emailTo=${emailTo:1}
         tryPassword=${emailPair[2]}
 
         # 1. if user has no password, then use the last seen password from other users.
@@ -86,7 +89,7 @@ function start_postfix {
         echo ">> Setting password[$password] for user $emailFrom ..."
         echo $password | saslpasswd2 $emailFrom
 
-        newLine=$(printf '%s\t%s' $emailFrom $emailTo)
+        newLine=$(printf '%s\t%s' $emailFrom "$emailTo")
         virtualUsers="${virtualUsers}${newLine}${NEWLINE}"
 
         domainFrom=${emailFrom##*@}


### PR DESCRIPTION
`export SMF_CONFIG='contact@somedomain.com:address1@otherdomain.com|address1@otherdomain.com'`