### PR TITLE
Allow own certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,22 +131,58 @@ You can also forward all emails received by testi@testo.com to multiple destinat
 $ export SMF_CONFIG='testi@testo.com:test1@test.com|test2@test.com|test3@test.com'
 ```
 
+TLS (SSL) Certificates
+--------------------
+SMF creates its own certificate and private key when starts. However, this certificate is self signed and so some systems might give you a warning about the server not being trusted.
+If you have valid certificates for the domain name of the host, then you can use them and avoid the warning about not being trusted.
+
+1. First you need to prepare the certificate files. Copy your full chain certificate to a file named `smtp.cert`. Then copy the private key to a file named `smtp.key`
+
+2. Copy these files to a folder. For example: `/data/certs/`. This folder will be mounted as a volume in SMF
+
+3. When creating the container, add the `-v` (volume) parameter to mount it to the folder `/etc/postfix/cert/` like so:
+ ```bash
+ $ docker run  -e SMF_CONFIG="$SMF_CONFIG" -p 25:25 -v /data/certs/:/etc/postfix/cert/ zixia/simple-mail-forwarder
+ ```
+4. Your emails should now be forwarded with trusted encryption. You can use this tool to test it: <a href="http://checktls.com/" target="_blank">http://checktls.com/</a>
+
+If you do not have a certificate and don't have the $$ to buy one, you can use <a href="https://letsencrypt.org" target="_blank">https://letsencrypt.org</a> if you have shell access to the server (Notice, SMF does not provide, yet, this service). Letsencrypt allows you to create valid trusted certificates for a server, if the server responds to the domain you specify. In order to do this, you need to run the program from within the server and have administrator rights.
+
+1. First install letsencrypt. This might vary by distribution, but in Ubuntu it is like this:
+
+ ```bash
+ $ sudo apt-get install letsencrypt
+ ```
+2. Stop any web server that might be using port 80 (Apache, nginx, etc)
+
+3. Determine all of the domains and subdomains that you want the certificate to cover, for example `mydomain.com`, `www.mydomain.com`, `smtp.mydomain.com`, etc. Remember to include the domain that SMF will respond to (as per MX record in DNS configuration of the domain)
+
+4. Execute the following command (you can add as many domains as you wish with the `-d` option. But remember, their DNS resolution must resolve to the server where `letsencrypt` is being executed)
+ ```bash
+ $ letsencrypt certonly --standalone -d yourdomain.com -d www.yourdomain.com -d mail.yourdomain.com
+ ```
+5. Follow the prompts and if everything is successful you will get your certificates in a folder like `/etc/letsencrypt/live/mydomain.com`
+
+6. You can now use those certificates to make SMF TLS trusted.
+
+> This was a quick way of how to use letsencrypt. For a full tutorial based on your OS see: <a href="https://certbot.eff.org/" tareget="_blank">https://certbot.eff.org/</a>
+
 Helper Scripts
 --------------------
 1. Build from source.
-```bash
-$ ./script/build.sh latest
-```
+ ```bash
+ $ ./script/build.sh latest
+ ```
 
 2. Run a self-test for SMF docker.
-```bash
-$ ./script/run.sh latest test
-```
+ ```bash
+ $ ./script/run.sh latest test
+ ```
 
 3. Get a shell inside SMF docker.
-```bash
-$ ./script/devshell.sh latest
-```
+ ```bash
+ $ ./script/devshell.sh latest
+ ```
 
 ### Manual Test
 ```bash

--- a/install/init-openssl.sh
+++ b/install/init-openssl.sh
@@ -5,12 +5,14 @@
 }
 
 cd /etc/postfix/cert
-
-#openssl dhparam -2 -out dh_512.pem 512
-#openssl dhparam -2 -out dh_1024.pem 1024
-openssl req -new -outform PEM -out smtp.cert -newkey rsa:2048 \
+# skip generation of certificate if one exists (by mounting a volume)
+if [ ! -f "smtp.cert" ]; then
+    #openssl dhparam -2 -out dh_512.pem 512
+    #openssl dhparam -2 -out dh_1024.pem 1024
+    openssl req -new -outform PEM -out smtp.cert -newkey rsa:2048 \
             -nodes -keyout smtp.key -keyform PEM -days 3650 -x509 \
             -subj "/C=US/ST=Matrix/L=L/O=O/CN=${SMF_DOMAIN:-simple-mail-forwarder.com}"
 
-chown -R root.postfix /etc/postfix/cert/
-chmod -R 750 /etc/postfix/cert/
+    chown -R root.postfix /etc/postfix/cert/
+    chmod -R 750 /etc/postfix/cert/
+fi

--- a/install/main.dist.cf
+++ b/install/main.dist.cf
@@ -737,5 +737,7 @@ smtpd_tls_exclude_ciphers =
 # openssl dhparam -2 -out dh_1024.pem 1024
 #smtpd_tls_dh512_param_file = ${config_directory}/cert/dh_512.pem
 #smtpd_tls_dh1024_param_file = ${config_directory}/cert/dh_1024.pem
+
 smtp_tls_security_level = may
+
 message_size_limit = 40960000


### PR DESCRIPTION
Skip generation of certificates if one already exists. This will allow the use of your own certificates via volume mounting