### PR TITLE
Update Base to Alpine 3.8

### DIFF
--- a/install/postfix.sh
+++ b/install/postfix.sh
@@ -13,8 +13,6 @@ daemon_directory=`$command_directory/postconf -h daemon_directory`
 $daemon_directory/master -t || $command_directory/postfix stop
 
 # make consistency check
-chown root /var/spool/postfix
-chown root /var/spool/postfix/pid
 $command_directory/postfix check >/dev/console 2>&1
 
 # run Postfix

--- a/install/syslog-ng.conf
+++ b/install/syslog-ng.conf
@@ -1,5 +1,11 @@
 @version: 3.9
 
+# Options
+options {
+  # Disable statistic log messages.
+  stats_freq(0);
+};
+
 # Sources
 source s_dgram {
   unix-dgram("/dev/log");

--- a/install/syslog-ng.conf
+++ b/install/syslog-ng.conf
@@ -1,0 +1,37 @@
+@version: 3.9
+
+# Sources
+source s_dgram {
+  unix-dgram("/dev/log");
+  internal();
+};
+
+# Filters
+filter f_out {
+  level(info..warn);
+};
+filter f_err {
+  level(err..emerg,debug);
+};
+
+# Destinations
+destination d_stdout {
+  pipe("/dev/stdout");
+};
+
+destination d_stderr {
+  pipe("/dev/stderr");
+};
+
+# Logs
+log {
+  source(s_dgram);
+  filter(f_out);
+  destination(d_stdout);
+};
+
+log {
+  source(s_dgram);
+  filter(f_err);
+  destination(d_stderr);
+};

--- a/install/syslog-ng.sh
+++ b/install/syslog-ng.sh
@@ -1,0 +1,3 @@
+#!/bin/execlineb -P
+
+/usr/sbin/syslog-ng --cfgfile=/etc/syslog-ng/syslog-ng.conf -F


### PR DESCRIPTION
This PR should resolve https://github.com/zixia/docker-simple-mail-forwarder/issues/39, and also updates everything to the latest and greatest tagged versions across the board.

* Update base image to Alpine 3.8
* As a part of the base change, the old "DNS" fixes that broke rancher/k8s are gone
* Install s6 process manager directly
* Upgraded BATS to 1.1.0
* Install syslog-ng for postfix logging to stdout